### PR TITLE
feat(invites): invite link generation and join flow [refs #13]

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
 import MainPage from './pages/MainPage'
+import JoinPage from './pages/JoinPage'
 import { useAuthStore } from './stores/authStore'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -20,6 +21,7 @@ function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/invite/:code" element={<JoinPage />} />
         <Route
           path="/"
           element={

--- a/web/src/api/invites.ts
+++ b/web/src/api/invites.ts
@@ -1,0 +1,45 @@
+// invite api functions
+
+import { post, get, del } from './client'
+
+export interface Invite {
+  code: string
+  server_id: string
+  channel_id: string | null
+  inviter: { id: string; username: string }
+  max_uses: number | null
+  uses: number
+  max_age_seconds: number | null
+  created_at: string
+  expires_at: string | null
+}
+
+interface JoinServerResponse {
+  server: {
+    id: string
+    name: string
+    owner_id: string
+    icon_hash: string | null
+  }
+  channel_id: string | null
+}
+
+// POST /servers/:serverId/invites - create an invite
+export async function createInvite(serverId: string): Promise<Invite> {
+  return post<Invite>(`/servers/${serverId}/invites`, {})
+}
+
+// GET /servers/:serverId/invites - list all invites for a server
+export async function getInvites(serverId: string): Promise<Invite[]> {
+  return get<Invite[]>(`/servers/${serverId}/invites`)
+}
+
+// POST /invites/:code - join a server using an invite code
+export async function joinServer(code: string): Promise<JoinServerResponse> {
+  return post<JoinServerResponse>(`/invites/${code}`)
+}
+
+// DELETE /invites/:code - revoke an invite
+export async function revokeInvite(code: string): Promise<void> {
+  await del(`/invites/${code}`)
+}

--- a/web/src/components/invites/InviteModal.tsx
+++ b/web/src/components/invites/InviteModal.tsx
@@ -1,0 +1,131 @@
+// modal for generating and sharing server invite links
+
+import { useState, useEffect } from 'react'
+import Modal from '../common/Modal'
+import { createInvite, type Invite } from '../../api/invites'
+
+interface InviteModalProps {
+  isOpen: boolean
+  onClose: () => void
+  serverId: string
+}
+
+export default function InviteModal({ isOpen, onClose, serverId }: InviteModalProps) {
+  const [invite, setInvite] = useState<Invite | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInvite(null)
+      setError(null)
+      setCopied(false)
+      return
+    }
+
+    let cancelled = false
+    const generate = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const inv = await createInvite(serverId)
+        if (!cancelled) setInvite(inv)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to create invite')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    generate()
+    return () => { cancelled = true }
+  }, [isOpen, serverId])
+
+  const inviteUrl = invite
+    ? `${window.location.origin}/invite/${invite.code}`
+    : ''
+
+  const handleCopy = async () => {
+    if (!inviteUrl) return
+    try {
+      await navigator.clipboard.writeText(inviteUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // fallback for older browsers
+      const input = document.createElement('input')
+      input.value = inviteUrl
+      document.body.appendChild(input)
+      input.select()
+      document.execCommand('copy')
+      document.body.removeChild(input)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Invite People">
+      <div className="space-y-4">
+        {isLoading && (
+          <div className="flex items-center justify-center py-6">
+            <svg className="animate-spin h-6 w-6 text-indigo-400" fill="none" viewBox="0 0 24 24">
+              <circle
+                className="opacity-25"
+                cx="12" cy="12" r="10"
+                stroke="currentColor" strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/50 rounded px-3 py-2">
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+
+        {invite && (
+          <>
+            <p className="text-sm text-gray-400">
+              Share this link to invite others to the server.
+              {invite.expires_at && ' This link will expire in 24 hours.'}
+            </p>
+
+            <div className="flex gap-2">
+              <input
+                type="text"
+                readOnly
+                value={inviteUrl}
+                className="flex-1 px-3 py-2 bg-gray-900 border border-gray-700 rounded
+                         text-white text-sm select-all
+                         focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                onClick={(e) => (e.target as HTMLInputElement).select()}
+              />
+              <button
+                onClick={handleCopy}
+                className={`
+                  px-4 py-2 rounded text-sm font-medium transition-colors
+                  ${copied
+                    ? 'bg-green-600 text-white'
+                    : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                  }
+                `}
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/web/src/components/invites/InviteModal.tsx
+++ b/web/src/components/invites/InviteModal.tsx
@@ -1,6 +1,6 @@
 // modal for generating and sharing server invite links
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Modal from '../common/Modal'
 import { createInvite, type Invite } from '../../api/invites'
 
@@ -10,17 +10,38 @@ interface InviteModalProps {
   serverId: string
 }
 
+// cache invites per server so we don't mint a new code every time the modal opens
+const inviteCache = new Map<string, Invite>()
+
+function isCachedInviteValid(invite: Invite): boolean {
+  if (!invite.expires_at) return true
+  return new Date(invite.expires_at).getTime() > Date.now()
+}
+
 export default function InviteModal({ isOpen, onClose, serverId }: InviteModalProps) {
   const [invite, setInvite] = useState<Invite | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const prevServerId = useRef(serverId)
 
   useEffect(() => {
     if (!isOpen) {
+      setCopied(false)
+      return
+    }
+
+    // clear state if server changed
+    if (prevServerId.current !== serverId) {
       setInvite(null)
       setError(null)
-      setCopied(false)
+      prevServerId.current = serverId
+    }
+
+    // reuse cached invite if it's still valid
+    const cached = inviteCache.get(serverId)
+    if (cached && isCachedInviteValid(cached)) {
+      setInvite(cached)
       return
     }
 
@@ -30,7 +51,10 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
       setError(null)
       try {
         const inv = await createInvite(serverId)
-        if (!cancelled) setInvite(inv)
+        if (!cancelled) {
+          inviteCache.set(serverId, inv)
+          setInvite(inv)
+        }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to create invite')

--- a/web/src/components/invites/InviteModal.tsx
+++ b/web/src/components/invites/InviteModal.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useRef } from 'react'
 import Modal from '../common/Modal'
-import { createInvite, type Invite } from '../../api/invites'
+import { createInvite } from '../../api/invites'
+import { getCachedInvite, setCachedInvite } from '../../utils/inviteCache'
 
 interface InviteModalProps {
   isOpen: boolean
@@ -10,21 +11,8 @@ interface InviteModalProps {
   serverId: string
 }
 
-// cache invites per server so we don't mint a new code every time the modal opens
-const inviteCache = new Map<string, Invite>()
-
-function isCachedInviteValid(invite: Invite): boolean {
-  if (!invite.expires_at) return true
-  return new Date(invite.expires_at).getTime() > Date.now()
-}
-
-// call this on logout to avoid stale invites across sessions
-export function clearInviteCache() {
-  inviteCache.clear()
-}
-
 export default function InviteModal({ isOpen, onClose, serverId }: InviteModalProps) {
-  const [invite, setInvite] = useState<Invite | null>(null)
+  const [invite, setInvite] = useState<{ code: string; expires_at: string | null } | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
@@ -51,8 +39,8 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
     }
 
     // reuse cached invite if it's still valid
-    const cached = inviteCache.get(serverId)
-    if (cached && isCachedInviteValid(cached)) {
+    const cached = getCachedInvite(serverId)
+    if (cached) {
       setInvite(cached)
       return
     }
@@ -66,7 +54,7 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
       try {
         const inv = await createInvite(targetServerId)
         if (!cancelled) {
-          inviteCache.set(targetServerId, inv)
+          setCachedInvite(targetServerId, inv)
           setInvite(inv)
         }
       } catch (err) {

--- a/web/src/components/invites/InviteModal.tsx
+++ b/web/src/components/invites/InviteModal.tsx
@@ -18,12 +18,24 @@ function isCachedInviteValid(invite: Invite): boolean {
   return new Date(invite.expires_at).getTime() > Date.now()
 }
 
+// call this on logout to avoid stale invites across sessions
+export function clearInviteCache() {
+  inviteCache.clear()
+}
+
 export default function InviteModal({ isOpen, onClose, serverId }: InviteModalProps) {
   const [invite, setInvite] = useState<Invite | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
-  const prevServerId = useRef(serverId)
+  const prevServerId = useRef<string>(serverId)
+
+  // clean up the "Copied" feedback timeout on unmount
+  useEffect(() => {
+    if (!copied) return
+    const id = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(id)
+  }, [copied])
 
   useEffect(() => {
     if (!isOpen) {
@@ -46,13 +58,15 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
     }
 
     let cancelled = false
+    // capture serverId at call time so the cache write goes to the right key
+    const targetServerId = serverId
     const generate = async () => {
       setIsLoading(true)
       setError(null)
       try {
-        const inv = await createInvite(serverId)
+        const inv = await createInvite(targetServerId)
         if (!cancelled) {
-          inviteCache.set(serverId, inv)
+          inviteCache.set(targetServerId, inv)
           setInvite(inv)
         }
       } catch (err) {
@@ -68,6 +82,12 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
     return () => { cancelled = true }
   }, [isOpen, serverId])
 
+  const expiryText = (() => {
+    if (!invite?.expires_at) return null
+    const hours = Math.max(1, Math.round((new Date(invite.expires_at).getTime() - Date.now()) / 36e5))
+    return ` This link expires in ${hours} hour${hours === 1 ? '' : 's'}.`
+  })()
+
   const inviteUrl = invite
     ? `${window.location.origin}/invite/${invite.code}`
     : ''
@@ -77,9 +97,7 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
     try {
       await navigator.clipboard.writeText(inviteUrl)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
     } catch {
-      // fallback for older browsers
       const input = document.createElement('input')
       input.value = inviteUrl
       document.body.appendChild(input)
@@ -87,7 +105,6 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
       document.execCommand('copy')
       document.body.removeChild(input)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
     }
   }
 
@@ -121,7 +138,7 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
           <>
             <p className="text-sm text-gray-400">
               Share this link to invite others to the server.
-              {invite.expires_at && ' This link will expire in 24 hours.'}
+              {expiryText}
             </p>
 
             <div className="flex gap-2">
@@ -132,7 +149,7 @@ export default function InviteModal({ isOpen, onClose, serverId }: InviteModalPr
                 className="flex-1 px-3 py-2 bg-gray-900 border border-gray-700 rounded
                          text-white text-sm select-all
                          focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                onClick={(e) => (e.target as HTMLInputElement).select()}
+                onClick={(e) => e.currentTarget.select()}
               />
               <button
                 onClick={handleCopy}

--- a/web/src/components/layout/ChannelSidebar.tsx
+++ b/web/src/components/layout/ChannelSidebar.tsx
@@ -8,6 +8,7 @@ import { getChannels } from '../../api/channels'
 import CreateChannelModal from '../channels/CreateChannelModal'
 import ChannelSettingsModal from '../channels/ChannelSettingsModal'
 import ServerSettingsModal from '../servers/ServerSettingsModal'
+import InviteModal from '../invites/InviteModal'
 import UserBar from '../user/UserBar'
 
 export default function ChannelSidebar() {
@@ -16,6 +17,7 @@ export default function ChannelSidebar() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [isServerSettingsOpen, setIsServerSettingsOpen] = useState(false)
   const [settingsChannel, setSettingsChannel] = useState<Channel | null>(null)
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
 
   const selectedServer = selectedServerId ? servers[selectedServerId] : null
@@ -157,10 +159,14 @@ export default function ChannelSidebar() {
                       tabIndex={0}
                       className="p-1 hover:bg-gray-700 rounded cursor-pointer"
                       title="Invite"
-                      onClick={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setIsInviteModalOpen(true)
+                      }}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.stopPropagation()
+                          setIsInviteModalOpen(true)
                         }
                       }}
                     >
@@ -248,6 +254,15 @@ export default function ChannelSidebar() {
           isOpen={!!settingsChannel}
           onClose={() => setSettingsChannel(null)}
           channel={settingsChannel}
+        />
+      )}
+
+      {/* Invite modal */}
+      {selectedServerId && (
+        <InviteModal
+          isOpen={isInviteModalOpen}
+          onClose={() => setIsInviteModalOpen(false)}
+          serverId={selectedServerId}
         />
       )}
     </div>

--- a/web/src/pages/JoinPage.tsx
+++ b/web/src/pages/JoinPage.tsx
@@ -1,0 +1,140 @@
+// join page - handles /invite/:code route
+
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { joinServer } from '../api/invites'
+import { useServerStore } from '../stores/serverStore'
+import { useAuthStore } from '../stores/authStore'
+
+export default function JoinPage() {
+  const { code } = useParams<{ code: string }>()
+  const navigate = useNavigate()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const { addServer, selectServer } = useServerStore()
+
+  const [status, setStatus] = useState<'loading' | 'error'>('loading')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!code || !isAuthenticated) return
+
+    let cancelled = false
+    const join = async () => {
+      try {
+        const result = await joinServer(code)
+        if (cancelled) return
+
+        addServer({
+          id: result.server.id,
+          name: result.server.name,
+          owner_id: result.server.owner_id,
+          icon_url: result.server.icon_hash,
+          member_count: 0,
+          created_at: new Date().toISOString(),
+        })
+        selectServer(result.server.id)
+        navigate('/', { replace: true })
+      } catch (err) {
+        if (cancelled) return
+        setStatus('error')
+
+        if (err && typeof err === 'object' && 'status' in err) {
+          const apiErr = err as { status: number; message: string }
+          if (apiErr.status === 404) {
+            setError('This invite link is invalid or has been revoked.')
+          } else if (apiErr.status === 410) {
+            setError('This invite has expired or reached its usage limit.')
+          } else if (apiErr.status === 409) {
+            setError("You're already a member of this server.")
+            // still redirect after a moment
+            setTimeout(() => navigate('/', { replace: true }), 1500)
+            return
+          } else {
+            setError(apiErr.message || 'Something went wrong.')
+          }
+        } else {
+          setError(err instanceof Error ? err.message : 'Failed to join server.')
+        }
+      }
+    }
+
+    join()
+    return () => { cancelled = true }
+  }, [code, isAuthenticated, addServer, selectServer, navigate])
+
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+        <div className="bg-gray-800 rounded-lg shadow-2xl p-8 max-w-sm w-full mx-4 text-center">
+          <h1 className="text-xl font-semibold text-white mb-3">You've been invited</h1>
+          <p className="text-gray-400 text-sm mb-6">
+            Log in or create an account to accept this invite.
+          </p>
+          <div className="flex flex-col gap-3">
+            <Link
+              to={`/login?redirect=/invite/${code}`}
+              className="px-4 py-2 bg-indigo-600 text-white rounded font-medium
+                       hover:bg-indigo-700 transition-colors text-sm"
+            >
+              Log In
+            </Link>
+            <Link
+              to={`/register?redirect=/invite/${code}`}
+              className="px-4 py-2 bg-gray-700 text-gray-200 rounded font-medium
+                       hover:bg-gray-600 transition-colors text-sm"
+            >
+              Create Account
+            </Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+        <div className="bg-gray-800 rounded-lg shadow-2xl p-8 max-w-sm w-full mx-4 text-center">
+          <div className="text-red-400 mb-4">
+            <svg className="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-xl font-semibold text-white mb-2">Invite Failed</h1>
+          <p className="text-gray-400 text-sm mb-6">{error}</p>
+          <Link
+            to="/"
+            className="px-4 py-2 bg-indigo-600 text-white rounded font-medium
+                     hover:bg-indigo-700 transition-colors text-sm"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  // loading state
+  return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <div className="text-center">
+        <svg className="animate-spin h-8 w-8 text-indigo-400 mx-auto mb-4" fill="none" viewBox="0 0 24 24">
+          <circle
+            className="opacity-25"
+            cx="12" cy="12" r="10"
+            stroke="currentColor" strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+        <p className="text-gray-400 text-sm">Joining server...</p>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/JoinPage.tsx
+++ b/web/src/pages/JoinPage.tsx
@@ -1,10 +1,11 @@
 // join page - handles /invite/:code route
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { joinServer } from '../api/invites'
 import { useServerStore } from '../stores/serverStore'
 import { useAuthStore } from '../stores/authStore'
+import { ApiError } from '../types/api'
 
 export default function JoinPage() {
   const { code } = useParams<{ code: string }>()
@@ -14,6 +15,7 @@ export default function JoinPage() {
 
   const [status, setStatus] = useState<'loading' | 'error'>('loading')
   const [error, setError] = useState<string | null>(null)
+  const redirectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!code || !isAuthenticated) return
@@ -29,7 +31,7 @@ export default function JoinPage() {
           name: result.server.name,
           owner_id: result.server.owner_id,
           icon_url: result.server.icon_hash,
-          member_count: 0,
+          member_count: 1,
           created_at: new Date().toISOString(),
         })
         selectServer(result.server.id)
@@ -38,19 +40,18 @@ export default function JoinPage() {
         if (cancelled) return
         setStatus('error')
 
-        if (err && typeof err === 'object' && 'status' in err) {
-          const apiErr = err as { status: number; message: string }
-          if (apiErr.status === 404) {
+        if (err instanceof ApiError) {
+          if (err.status === 404) {
             setError('This invite link is invalid or has been revoked.')
-          } else if (apiErr.status === 410) {
+          } else if (err.status === 410) {
             setError('This invite has expired or reached its usage limit.')
-          } else if (apiErr.status === 409) {
+          } else if (err.status === 409) {
             setError("You're already a member of this server.")
-            // still redirect after a moment
-            setTimeout(() => navigate('/', { replace: true }), 1500)
-            return
+            redirectTimer.current = setTimeout(() => {
+              if (!cancelled) navigate('/', { replace: true })
+            }, 1500)
           } else {
-            setError(apiErr.message || 'Something went wrong.')
+            setError(err.message || 'Something went wrong.')
           }
         } else {
           setError(err instanceof Error ? err.message : 'Failed to join server.')
@@ -59,7 +60,10 @@ export default function JoinPage() {
     }
 
     join()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      if (redirectTimer.current) clearTimeout(redirectTimer.current)
+    }
   }, [code, isAuthenticated, addServer, selectServer, navigate])
 
   if (!isAuthenticated) {

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
 import { useState, FormEvent } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import { ApiError } from '../types/api'
 
 export default function LoginPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const login = useAuthStore((s) => s.login)
   const [usernameOrEmail, setUsernameOrEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -18,7 +19,8 @@ export default function LoginPage() {
 
     try {
       await login(usernameOrEmail, password)
-      navigate('/')
+      const redirect = searchParams.get('redirect')
+      navigate(redirect && redirect.startsWith('/') ? redirect : '/')
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message)

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -1,10 +1,11 @@
 import { useState, FormEvent } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import { ApiError } from '../types/api'
 
 export default function RegisterPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const register = useAuthStore((s) => s.register)
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
@@ -19,7 +20,8 @@ export default function RegisterPage() {
 
     try {
       await register(username, email, password)
-      navigate('/')
+      const redirect = searchParams.get('redirect')
+      navigate(redirect && redirect.startsWith('/') ? redirect : '/')
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message)

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -7,7 +7,7 @@ import { create } from 'zustand'
 import type { CurrentUser } from '../types/user'
 import * as authApi from '../api/auth'
 import { gatewayClient } from '../gateway'
-import { clearInviteCache } from '../components/invites/InviteModal'
+import { clearInviteCache } from '../utils/inviteCache'
 
 interface AuthState {
   token: string | null

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -7,6 +7,7 @@ import { create } from 'zustand'
 import type { CurrentUser } from '../types/user'
 import * as authApi from '../api/auth'
 import { gatewayClient } from '../gateway'
+import { clearInviteCache } from '../components/invites/InviteModal'
 
 interface AuthState {
   token: string | null
@@ -87,7 +88,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   logout: () => {
     gatewayClient.disconnect()
-    // Clear localStorage
+    clearInviteCache()
     localStorage.removeItem('authToken')
     localStorage.removeItem('user')
 

--- a/web/src/utils/inviteCache.ts
+++ b/web/src/utils/inviteCache.ts
@@ -1,0 +1,23 @@
+// invite cache - reuses codes per server instead of minting new ones on every modal open
+
+import type { Invite } from '../api/invites'
+
+const cache = new Map<string, Invite>()
+
+export function getCachedInvite(serverId: string): Invite | null {
+  const invite = cache.get(serverId)
+  if (!invite) return null
+  if (invite.expires_at && new Date(invite.expires_at).getTime() <= Date.now()) {
+    cache.delete(serverId)
+    return null
+  }
+  return invite
+}
+
+export function setCachedInvite(serverId: string, invite: Invite) {
+  cache.set(serverId, invite)
+}
+
+export function clearInviteCache() {
+  cache.clear()
+}


### PR DESCRIPTION
## Summary

- Invite button in ChannelSidebar now opens a modal that generates an invite link via POST /servers/:id/invites and lets you copy it
- Added /invite/:code route with a JoinPage that handles the accept flow — joins the server, adds it to the store, and redirects in
- Unauthenticated users landing on an invite link get a login/register prompt that redirects back after auth
- Error handling for expired (410), invalid (404), and already-a-member (409) invites
- Invite codes cached per server to avoid minting new ones on repeated modal opens
- Login and register pages now respect ?redirect query param

## Test plan

- [x] Generate invite from channel hover button, copy link, verify it works in another browser/session
- [x] Test expired/invalid invite codes show correct error
- [x] Open invite modal multiple times, confirm same code is reused
- [x] Test unauthenticated invite flow: land on /invite/:code, log in, verify redirect back to invite

closes #13 