### PR TITLE
feat(messages): scroll-to-load-more pagination, useEffect dep fixes, atomic message store

### DIFF
--- a/web/src/api/messages.ts
+++ b/web/src/api/messages.ts
@@ -18,12 +18,16 @@ export async function sendMessage(channelId: string, content: string): Promise<M
 }
 
 // GET /channels/:channelId/messages - fetch message history
+// pass `before` to paginate backwards from a given message ID
 export async function getMessages(
   channelId: string,
-  limit: number = 50
+  limit: number = 50,
+  before?: string,
 ): Promise<Message[]> {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (before) params.set('before', before)
   const response = await get<GetMessagesResponse>(
-    `/channels/${channelId}/messages?limit=${limit}`
+    `/channels/${channelId}/messages?${params.toString()}`
   )
   return response.messages
 }
@@ -41,4 +45,3 @@ export async function deleteMessage(messageId: string): Promise<void> {
   await del(`/messages/${messageId}`)
 }
 
-// TODO: pagination with before/after cursors - add when we implement scroll-to-load-more

--- a/web/src/components/layout/ChannelSidebar.tsx
+++ b/web/src/components/layout/ChannelSidebar.tsx
@@ -27,10 +27,13 @@ export default function ChannelSidebar() {
       )
     : []
 
+  // derived boolean — avoids putting the entire channelsByServer object in effect deps,
+  // which would re-run on any channel mutation across any server
+  const hasChannelsLoaded = selectedServerId != null && !!channelsByServer[selectedServerId]
+
   // fetch channels when server is selected
   useEffect(() => {
-    if (!selectedServerId) return
-    if (channelsByServer[selectedServerId]) return
+    if (!selectedServerId || hasChannelsLoaded) return
 
     let cancelled = false
     const fetchServerChannels = async () => {
@@ -55,7 +58,7 @@ export default function ChannelSidebar() {
     return () => {
       cancelled = true
     }
-  }, [selectedServerId, channelsByServer, setChannels])
+  }, [selectedServerId, hasChannelsLoaded, setChannels])
 
   if (!selectedServer) {
     return (

--- a/web/src/components/messages/MessageInput.tsx
+++ b/web/src/components/messages/MessageInput.tsx
@@ -23,6 +23,8 @@ export default function MessageInput() {
   const handleSubmit = async () => {
     if (!content.trim() || !selectedChannelId || isSending) return
 
+    // capture channel at send time — selectedChannelId may change while request is in flight
+    const channelId = selectedChannelId
     const messageContent = content.trim()
     setContent('')
     setIsSending(true)
@@ -34,7 +36,7 @@ export default function MessageInput() {
     const tempId = `temp-${Date.now()}`
     const tempMessage: Message = {
       id: tempId,
-      channel_id: selectedChannelId,
+      channel_id: channelId,
       author: {
         id: 'temp',
         username: 'You',
@@ -49,16 +51,19 @@ export default function MessageInput() {
 
     try {
       addMessage(tempMessage)
-      const sentMessage = await sendMessage(selectedChannelId, messageContent)
+      const sentMessage = await sendMessage(channelId, messageContent)
 
-      const { removeMessage } = useMessageStore.getState()
-      removeMessage(selectedChannelId, tempId)
-      addMessage(sentMessage)
+      // atomic swap — no render gap between remove and add
+      const { replaceMessage } = useMessageStore.getState()
+      replaceMessage(channelId, tempId, sentMessage)
     } catch (err) {
       console.error('failed to send message:', err)
       const { removeMessage } = useMessageStore.getState()
-      removeMessage(selectedChannelId, tempId)
-      setContent(messageContent)
+      removeMessage(channelId, tempId)
+      // only restore input if the user is still on the same channel
+      if (useChannelStore.getState().selectedChannelId === channelId) {
+        setContent(messageContent)
+      }
     } finally {
       setIsSending(false)
     }

--- a/web/src/components/messages/MessageList.tsx
+++ b/web/src/components/messages/MessageList.tsx
@@ -8,18 +8,30 @@ import MessageItem from './MessageItem'
 
 export default function MessageList() {
   const { selectedChannelId } = useChannelStore()
-  const { messagesByChannel, setMessages, getMessagesForChannel } = useMessageStore()
+  const {
+    messagesByChannel,
+    setMessages,
+    prependMessages,
+    getMessagesForChannel,
+    getOldestMessageId,
+    hasReachedChannelStart,
+  } = useMessageStore()
   const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [showNewMessages, setShowNewMessages] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const prevMessageCountRef = useRef(0)
   const isNearBottomRef = useRef(true)
+  const isFetchingMoreRef = useRef(false)
 
   const messages = selectedChannelId ? getMessagesForChannel(selectedChannelId) : []
 
   // fetch messages when channel changes
   useEffect(() => {
     if (!selectedChannelId) return
+
+    // reset load-more lock on channel switch
+    isFetchingMoreRef.current = false
 
     if (messagesByChannel[selectedChannelId]) {
       scrollToBottom()
@@ -64,7 +76,40 @@ export default function MessageList() {
     prevMessageCountRef.current = messages.length
   }, [messages.length])
 
-  // track scroll position
+  // fetch older messages using the oldest known message ID as cursor
+  const loadMoreMessages = async () => {
+    if (!selectedChannelId) return
+    if (isFetchingMoreRef.current) return
+    if (hasReachedChannelStart(selectedChannelId)) return
+
+    const before = getOldestMessageId(selectedChannelId)
+    if (!before) return
+
+    isFetchingMoreRef.current = true
+    setIsLoadingMore(true)
+
+    // snapshot scroll position so we can restore it after prepending
+    const container = scrollRef.current
+    const scrollHeightBefore = container?.scrollHeight ?? 0
+
+    try {
+      const older = await getMessages(selectedChannelId, 50, before)
+      prependMessages(selectedChannelId, older)
+
+      // restore scroll position — shift by how much height was added at top
+      if (container) {
+        const added = container.scrollHeight - scrollHeightBefore
+        container.scrollTop += added
+      }
+    } catch (err) {
+      console.error('failed to load older messages:', err)
+    } finally {
+      setIsLoadingMore(false)
+      isFetchingMoreRef.current = false
+    }
+  }
+
+  // track scroll position and trigger pagination near top
   const handleScroll = () => {
     if (!scrollRef.current) return
     const { scrollTop, scrollHeight, clientHeight } = scrollRef.current
@@ -72,6 +117,9 @@ export default function MessageList() {
     isNearBottomRef.current = distanceFromBottom < 100
     if (isNearBottomRef.current) {
       setShowNewMessages(false)
+    }
+    if (scrollTop < 100) {
+      loadMoreMessages()
     }
   }
 
@@ -139,6 +187,18 @@ export default function MessageList() {
         onScroll={handleScroll}
         className="absolute inset-0 overflow-y-auto px-4 py-4"
       >
+        {/* top-of-history markers */}
+        {selectedChannelId && hasReachedChannelStart(selectedChannelId) && (
+          <div className="text-center py-4 mb-2">
+            <p className="text-gray-500 text-xs">Beginning of conversation</p>
+          </div>
+        )}
+        {isLoadingMore && (
+          <div className="text-center py-3">
+            <p className="text-gray-500 text-xs">Loading older messages...</p>
+          </div>
+        )}
+
         {groupedMessages.map(({ message, isGrouped }) => (
           <MessageItem key={message.id} message={message} isGrouped={isGrouped} />
         ))}

--- a/web/src/components/messages/MessageList.tsx
+++ b/web/src/components/messages/MessageList.tsx
@@ -26,6 +26,10 @@ export default function MessageList() {
 
   const messages = selectedChannelId ? getMessagesForChannel(selectedChannelId) : []
 
+  // derived boolean — avoids putting the entire messagesByChannel object in effect deps,
+  // which would re-run on any new message in any channel
+  const hasMessagesLoaded = selectedChannelId != null && !!messagesByChannel[selectedChannelId]
+
   // fetch messages when channel changes
   useEffect(() => {
     if (!selectedChannelId) return
@@ -33,7 +37,7 @@ export default function MessageList() {
     // reset load-more lock on channel switch
     isFetchingMoreRef.current = false
 
-    if (messagesByChannel[selectedChannelId]) {
+    if (hasMessagesLoaded) {
       scrollToBottom()
       return
     }
@@ -62,7 +66,7 @@ export default function MessageList() {
     return () => {
       cancelled = true
     }
-  }, [selectedChannelId, messagesByChannel, setMessages])
+  }, [selectedChannelId, hasMessagesLoaded, setMessages])
 
   // auto-scroll on new messages
   useEffect(() => {

--- a/web/src/components/messages/MessageList.tsx
+++ b/web/src/components/messages/MessageList.tsx
@@ -6,6 +6,9 @@ import { useChannelStore } from '../../stores/channelStore'
 import { getMessages } from '../../api/messages'
 import MessageItem from './MessageItem'
 
+const SCROLL_BOTTOM_THRESHOLD = 100  // px from bottom — show "new messages" badge
+const SCROLL_TOP_THRESHOLD = 100     // px from top — trigger load-more
+
 export default function MessageList() {
   const { selectedChannelId } = useChannelStore()
   const {
@@ -82,11 +85,13 @@ export default function MessageList() {
 
   // fetch older messages using the oldest known message ID as cursor
   const loadMoreMessages = async () => {
-    if (!selectedChannelId) return
+    // capture channel at call time — selectedChannelId may change while request is in flight
+    const channelId = selectedChannelId
+    if (!channelId) return
     if (isFetchingMoreRef.current) return
-    if (hasReachedChannelStart(selectedChannelId)) return
+    if (hasReachedChannelStart(channelId)) return
 
-    const before = getOldestMessageId(selectedChannelId)
+    const before = getOldestMessageId(channelId)
     if (!before) return
 
     isFetchingMoreRef.current = true
@@ -97,8 +102,12 @@ export default function MessageList() {
     const scrollHeightBefore = container?.scrollHeight ?? 0
 
     try {
-      const older = await getMessages(selectedChannelId, 50, before)
-      prependMessages(selectedChannelId, older)
+      const older = await getMessages(channelId, 50, before)
+
+      // discard if user switched channels while request was in flight
+      if (useChannelStore.getState().selectedChannelId !== channelId) return
+
+      prependMessages(channelId, older)
 
       // restore scroll position — shift by how much height was added at top
       if (container) {
@@ -118,11 +127,11 @@ export default function MessageList() {
     if (!scrollRef.current) return
     const { scrollTop, scrollHeight, clientHeight } = scrollRef.current
     const distanceFromBottom = scrollHeight - scrollTop - clientHeight
-    isNearBottomRef.current = distanceFromBottom < 100
+    isNearBottomRef.current = distanceFromBottom < SCROLL_BOTTOM_THRESHOLD
     if (isNearBottomRef.current) {
       setShowNewMessages(false)
     }
-    if (scrollTop < 100) {
+    if (scrollTop < SCROLL_TOP_THRESHOLD) {
       loadMoreMessages()
     }
   }
@@ -191,17 +200,16 @@ export default function MessageList() {
         onScroll={handleScroll}
         className="absolute inset-0 overflow-y-auto px-4 py-4"
       >
-        {/* top-of-history markers */}
-        {selectedChannelId && hasReachedChannelStart(selectedChannelId) && (
-          <div className="text-center py-4 mb-2">
-            <p className="text-gray-500 text-xs">Beginning of conversation</p>
-          </div>
-        )}
-        {isLoadingMore && (
+        {/* top-of-history marker — mutually exclusive states, loading takes precedence */}
+        {isLoadingMore ? (
           <div className="text-center py-3">
             <p className="text-gray-500 text-xs">Loading older messages...</p>
           </div>
-        )}
+        ) : selectedChannelId && hasReachedChannelStart(selectedChannelId) ? (
+          <div className="text-center py-4 mb-2">
+            <p className="text-gray-500 text-xs">Beginning of conversation</p>
+          </div>
+        ) : null}
 
         {groupedMessages.map(({ message, isGrouped }) => (
           <MessageItem key={message.id} message={message} isGrouped={isGrouped} />

--- a/web/src/stores/messageStore.ts
+++ b/web/src/stores/messageStore.ts
@@ -21,9 +21,7 @@ interface MessageState {
   removeMessage: (channelId: string, messageId: string) => void
   updateMessage: (channelId: string, messageId: string, updates: Partial<Message>) => void
   getMessagesForChannel: (channelId: string) => Message[]
-  setOldestMessageId: (channelId: string, messageId: string | null) => void
   getOldestMessageId: (channelId: string) => string | null
-  markChannelStart: (channelId: string) => void
   hasReachedChannelStart: (channelId: string) => boolean
 }
 
@@ -44,6 +42,8 @@ export const useMessageStore = create<MessageState>((set, get) => ({
     set((state) => {
       const update: Partial<MessageState> = {
         messagesByChannel: { ...state.messagesByChannel, [channelId]: messagesMap },
+        // clear pagination state when a channel's messages are reset
+        hasReachedStart: { ...state.hasReachedStart, [channelId]: false },
       }
       if (messages.length > 0) {
         const oldest = [...messages].sort(
@@ -153,26 +153,8 @@ export const useMessageStore = create<MessageState>((set, get) => ({
     )
   },
 
-  setOldestMessageId: (channelId: string, messageId: string | null) => {
-    set((state) => ({
-      oldestMessageId: {
-        ...state.oldestMessageId,
-        [channelId]: messageId,
-      },
-    }))
-  },
-
   getOldestMessageId: (channelId: string) => {
     return get().oldestMessageId[channelId] || null
-  },
-
-  markChannelStart: (channelId: string) => {
-    set((state) => ({
-      hasReachedStart: {
-        ...state.hasReachedStart,
-        [channelId]: true,
-      },
-    }))
   },
 
   hasReachedChannelStart: (channelId: string) => {
@@ -186,25 +168,19 @@ gatewayClient.on<{ message: Message }>(MESSAGE_CREATE, (payload) => {
   const channelMessages = messagesByChannel[payload.message.channel_id]
 
   // skip if we already have this message (from optimistic update)
-  if (channelMessages && channelMessages[payload.message.id]) {
-    console.log('[MessageStore] MESSAGE_CREATE: already exists, skipping')
-    return
-  }
+  if (channelMessages && channelMessages[payload.message.id]) return
 
-  console.log('[MessageStore] MESSAGE_CREATE: adding message to', payload.message.channel_id)
   addMessage(payload.message)
 })
 
 // handle MESSAGE_UPDATE events
 gatewayClient.on<{ message: Message }>(MESSAGE_UPDATE, (payload) => {
   const { updateMessage } = useMessageStore.getState()
-  console.log('[MessageStore] MESSAGE_UPDATE: updating message', payload.message.id)
   updateMessage(payload.message.channel_id, payload.message.id, payload.message)
 })
 
 // handle MESSAGE_DELETE events
 gatewayClient.on<{ id: string; channel_id: string }>(MESSAGE_DELETE, (payload) => {
   const { removeMessage } = useMessageStore.getState()
-  console.log('[MessageStore] MESSAGE_DELETE: removing message', payload.id)
   removeMessage(payload.channel_id, payload.id)
 })

--- a/web/src/stores/messageStore.ts
+++ b/web/src/stores/messageStore.ts
@@ -17,6 +17,7 @@ interface MessageState {
   setMessages: (channelId: string, messages: Message[]) => void
   addMessage: (message: Message) => void
   prependMessages: (channelId: string, messages: Message[]) => void
+  replaceMessage: (channelId: string, oldId: string, message: Message) => void
   removeMessage: (channelId: string, messageId: string) => void
   updateMessage: (channelId: string, messageId: string, updates: Partial<Message>) => void
   getMessagesForChannel: (channelId: string) => Message[]
@@ -40,25 +41,18 @@ export const useMessageStore = create<MessageState>((set, get) => ({
       {} as Record<string, Message>,
     )
 
-    set((state) => ({
-      messagesByChannel: {
-        ...state.messagesByChannel,
-        [channelId]: messagesMap,
-      },
-    }))
-
-    // Update oldest message ID if messages exist
-    if (messages.length > 0) {
-      const sortedMessages = [...messages].sort(
-        (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-      )
-      set((state) => ({
-        oldestMessageId: {
-          ...state.oldestMessageId,
-          [channelId]: sortedMessages[0].id,
-        },
-      }))
-    }
+    set((state) => {
+      const update: Partial<MessageState> = {
+        messagesByChannel: { ...state.messagesByChannel, [channelId]: messagesMap },
+      }
+      if (messages.length > 0) {
+        const oldest = [...messages].sort(
+          (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+        )[0]
+        update.oldestMessageId = { ...state.oldestMessageId, [channelId]: oldest.id }
+      }
+      return update
+    })
   },
 
   addMessage: (message: Message) => {
@@ -76,48 +70,46 @@ export const useMessageStore = create<MessageState>((set, get) => ({
     })
   },
 
+  // atomically swap a temp optimistic message for the real one — no render between remove and add
+  replaceMessage: (channelId: string, oldId: string, message: Message) => {
+    set((state) => {
+      const channelMessages = state.messagesByChannel[channelId]
+      if (!channelMessages) return state
+      const { [oldId]: _, ...rest } = channelMessages
+      return {
+        messagesByChannel: {
+          ...state.messagesByChannel,
+          [channelId]: { ...rest, [message.id]: message },
+        },
+      }
+    })
+  },
+
   prependMessages: (channelId: string, messages: Message[]) => {
     if (messages.length === 0) {
-      // No more messages, mark as reached start
       set((state) => ({
-        hasReachedStart: {
-          ...state.hasReachedStart,
-          [channelId]: true,
-        },
+        hasReachedStart: { ...state.hasReachedStart, [channelId]: true },
       }))
       return
     }
 
-    set((state) => {
-      const channelMessages = state.messagesByChannel[channelId] || {}
-      const newMessages = messages.reduce(
-        (acc, message) => {
-          acc[message.id] = message
-          return acc
-        },
-        {} as Record<string, Message>,
-      )
-
-      return {
-        messagesByChannel: {
-          ...state.messagesByChannel,
-          [channelId]: {
-            ...newMessages,
-            ...channelMessages,
-          },
-        },
-      }
-    })
-
-    // Update oldest message ID
-    const sortedMessages = [...messages].sort(
-      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-    )
-    set((state) => ({
-      oldestMessageId: {
-        ...state.oldestMessageId,
-        [channelId]: sortedMessages[0].id,
+    const newMessages = messages.reduce(
+      (acc, message) => {
+        acc[message.id] = message
+        return acc
       },
+      {} as Record<string, Message>,
+    )
+    const oldest = [...messages].sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    )[0]
+
+    set((state) => ({
+      messagesByChannel: {
+        ...state.messagesByChannel,
+        [channelId]: { ...newMessages, ...state.messagesByChannel[channelId] },
+      },
+      oldestMessageId: { ...state.oldestMessageId, [channelId]: oldest.id },
     }))
   },
 


### PR DESCRIPTION
## What's in here

Fixes #17, #23, #24 — message pagination, atomic optimistic updates, and unnecessary effect re-runs.

### #17 — Scroll-to-load-more pagination
Wired the existing store pagination infrastructure to the UI. `getMessages` now accepts a `before` cursor built with `URLSearchParams`. `MessageList` detects scroll position within 100px of the top and loads older messages, preserving scroll position via height delta so the view doesn't jump. A ref gates concurrent fetches. Shows "Loading older messages..." while fetching and "Beginning of conversation" once history is exhausted.

### #23 — Optimistic update atomicity
`setMessages` and `prependMessages` each did two separate `set()` calls, leaving a render window where subscribers saw new messages alongside a stale `oldestMessageId`. Merged both into a single `set()`. Added `replaceMessage` to atomically swap temp → real message in one operation — `MessageInput` now uses it instead of `removeMessage` + `addMessage`, eliminating the visible flicker. `selectedChannelId` is captured into a local at the start of `handleSubmit` so the send, cleanup, and failure paths all reference the channel that was active at send time. Content restore on failure is guarded — skipped if the user switched channels mid-flight.

### #24 — useEffect dep narrowing
`ChannelSidebar` and `MessageList` both listed the full store map (`channelsByServer`, `messagesByChannel`) as effect deps. Any mutation in any server or channel caused those effects to re-evaluate even when the active context hadn't changed. Replaced with derived booleans (`hasChannelsLoaded`, `hasMessagesLoaded`) that only flip when the relevant key appears.

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `npm run build` — clean, 0 warnings
- [x] `npm run lint` — 0 warnings
- [ ] Scroll up in a channel with history — older messages load without scroll jump
- [ ] Reach the beginning — "Beginning of conversation" appears, no further requests fire
- [ ] Switch channels mid-load — no stale state bleeds across
- [ ] Send a message — no flicker when temp swaps to real
- [ ] Receive a message in another channel — no unnecessary refetch triggers